### PR TITLE
remove email verify

### DIFF
--- a/lib/passport-configurator.js
+++ b/lib/passport-configurator.js
@@ -296,7 +296,7 @@ PassportConfigurator.prototype.configureProvider = function(name, options) {
                         done(null, false, {message: g.f('Failed to create token.')}) :
                         done(err);
                     }
-                    if (accessToken && user.emailVerified) {
+                    if (accessToken && user) {
                       userProfile.accessToken = accessToken;
                       done(null, userProfile, {accessToken: accessToken});
                     } else {


### PR DESCRIPTION
There is one more instance of email verify this component that I left, this is for the case of not using accessTokens (sessions instead) so we aren't using it (i'm pretty sure)